### PR TITLE
Update hyperlinks in README files

### DIFF
--- a/en/readme.md
+++ b/en/readme.md
@@ -2,29 +2,29 @@
 
 ## Intro
 
-- [Preface](preface.md#prefacio)
-- [Model, view, controller (MVC)](mvc.md#modelo,-vista,-controlador-mvc)
+- [Preface](preface.md)
+- [Model, view, controller (MVC)](mvc.md)
 
 ## How to start
 
-- [Install KumbiaPHP](to-install.md#instalar-kumbiaphp)
-- [My first app with KumbiaPHP](first-app.md#mi-primera-aplicación-con-kumbiaphp)
+- [Install KumbiaPHP](to-install.md)
+- [My first app with KumbiaPHP](first-app.md)
 
 ## MVC components
 
-- [Controller](controller.md#el-controlador)
-- [Models](model.md#5-modelos)
-- [View](view.md#la-vista)
+- [Controller](controller.md)
+- [Models](model.md)
+- [View](view.md)
 - [CRUD](crud.md)
 
 ## Other Components
 
 - [ActiveRecord](active-record.md)
-- [Parent classes](parent-class.md#clases-padre)
-- [Console](console.md#la-consola)
+- [Parent classes](parent-class.md)
+- [Console](console.md)
 
 ## Appendices
 
-- [Appendices](appendix.md#apendices)
+- [Appendices](appendix.md)
 
 [Full topic list](index.md)

--- a/es/readme.md
+++ b/es/readme.md
@@ -2,30 +2,30 @@
 
 ## Introducción
 
-- [Prefacio](preface.md#prefacio)
-- [Modelo, Vista, Controlador (MVC)](mvc.md#modelo,-vista,-controlador-mvc)
+- [Prefacio](preface.md)
+- [Modelo, Vista, Controlador (MVC)](mvc.md)
 
 ## Como empezar
 
-- [Instalar KumbiaPHP](to-install.md#instalar-kumbiaphp)
-- [Mi Primera Aplicación con KumbiaPHP](first-app.md#mi-primera-aplicación-con-kumbiaphp)
+- [Instalar KumbiaPHP](to-install.md)
+- [Mi Primera Aplicación con KumbiaPHP](first-app.md)
 
 ## Componentes MVC
 
-- [Controlador](controller.md#el-controlador)
-- [Modelos](model.md#5-modelos)
-- [Vista](view.md#la-vista)
+- [Controlador](controller.md)
+- [Modelos](model.md)
+- [Vista](view.md)
 - [CRUD](crud.md)
 
 ## Otros componentes
 
 - [ActiveRecord](active-record.md)
-- [Clases padre](parent-class.md#clases-padre)
-- [Consola](console.md#la-consola)
+- [Clases padre](parent-class.md)
+- [Consola](console.md)
 
 ## Apéndices
 
-- [Apéndices](appendix.md#apendices)
+- [Apéndices](appendix.md)
 
 
 [Lista detallada de temas](index.md)


### PR DESCRIPTION
This commit removes specific anchors from hyperlinks in both English and Spanish README files, now all the links point to the top of their respective pages. This change provides more flexibility for potential structure changes within these pages.