### PR TITLE
Add version availability info to config/exception feature

### DIFF
--- a/en/configuration.md
+++ b/en/configuration.md
@@ -96,7 +96,8 @@ can significantly improve the application's performance and consistency.
 
 The `config/exception.php` file in KumbiaPHP allows configuring the IP addresses from which exception details will be
 displayed instead of a generic 404 error. This functionality is especially useful during the development phase, where
-developers need to see error traces and specific details to debug effectively.
+developers need to see error traces and specific details to debug effectively. This feature is available from version
+1.2.0 onwards.
 
 ### File Location
 

--- a/en/configuration.md
+++ b/en/configuration.md
@@ -92,7 +92,7 @@ When configuring this file, it is crucial to ensure that parameters such as `deb
 production environments to maintain security. Additionally, choosing the appropriate caching mechanism and date format
 can significantly improve the application's performance and consistency.
 
-## Configuration: `config/exception.php` File
+## Configuration: `config/exception.php` File (v 1.2)
 
 The `config/exception.php` file in KumbiaPHP allows configuring the IP addresses from which exception details will be
 displayed instead of a generic 404 error. This functionality is especially useful during the development phase, where


### PR DESCRIPTION
This commit adds specific information to the `config/exception.php` configuration feature in KumbiaPHP documentation. It clarifies that this important debugging feature is available from version 1.2.0 onwards.