### PR TITLE
Update 'trustedIp' documentation in Spanish configuration guide 

### DIFF
--- a/es/configuration.md
+++ b/es/configuration.md
@@ -96,7 +96,7 @@ Al configurar este archivo, es fundamental asegurarse de que los parámetros com
 deshabilitados en entornos de producción para mantener la seguridad. Además, elegir el mecanismo de caché y formato de
 fechas adecuado puede mejorar significativamente el rendimiento y la consistencia de la aplicación.
 
-## Configuración: Archivo `config/exception.php`
+## Configuración: Archivo `config/exception.php` (v 1.2)
 
 El archivo `config/exception.php` en KumbiaPHP permite configurar las direcciones IP desde las cuales se mostrarán los
 detalles de las excepciones en lugar de un error 404 genérico. Esta funcionalidad es especialmente útil durante la fase

--- a/es/configuration.md
+++ b/es/configuration.md
@@ -123,7 +123,8 @@ return [
 ### Configuración de IPs Confiables
 El array `trustedIp` debe ser configurado con las direcciones IP desde las cuales se permitirá mostrar los detalles
 completos de las excepciones. Esto es útil cuando se quiere permitir que ciertos desarrolladores o equipos de desarrollo
-accedan a esta información desde ubicaciones específicas.
+accedan a esta información desde ubicaciones específicas. Esta característica está disponible desde la versión 1.2.0 en
+adelante.
 
 **Ejemplo:**
 ```php

--- a/es/index.md
+++ b/es/index.md
@@ -38,7 +38,7 @@
     - [Probando el CRUD](crud.md#probando-el-crud)
 - [Archivos de configuración](configuration.md)
   - [config/config.php](configuration.md#configuración-archivo-configconfigphp)
-  - [config/exception.php](configuration.md#configuración-archivo-configexceptionphp)
+  - [config/exception.php](configuration.md#configuración-archivo-configexceptionphp-v-12)
 
 ## Componentes MCV
 - [El Controlador](controller.md#el-controlador)


### PR DESCRIPTION
Expanded on the description of the 'trustedIp' feature in the Spanish configuration guide. Added information about when this feature became available, stating that it's been available since version 1.2.0.